### PR TITLE
Fix: Add "test" script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
-    "dev": "nodemon --watch build --exec \"node build/index.js\""
+    "dev": "nodemon --watch build --exec \"node build/index.js\"",
+    "test": "jest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",


### PR DESCRIPTION
Added `"test": "jest"` to the scripts section of `package.json` to allow running the unit tests with `npm test`. Verified that all existing Jest tests pass successfully.

---
*PR created automatically by Jules for task [5442121094173724613](https://jules.google.com/task/5442121094173724613) started by @Mallikarjun-Roddannavar*