### PR TITLE
🔒 Fix LLM Prompt Injection via System/User Role Separation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,20 +122,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     logger.info(
       `[Step2] Building LLM prompt for endpoint ${endpoint} (${method})`
     );
-    let prompt = `You are a Test Engineer. Please create a comprehensive test plan for the API endpoint:\n${String(
-      method
-    ).toUpperCase()} ${endpoint}\n`;
-    if (payload && Object.keys(payload).length > 0) {
-      prompt += `\nSample Payload:\n${JSON.stringify(payload, null, 2)}\n`;
-    }
-    prompt += fs.readFileSync(
+
+    // Static instructions and guidelines go in the system prompt
+    let systemPrompt = `You are a Test Engineer. Please create a comprehensive test plan for the provided API endpoint.\n`;
+    systemPrompt += fs.readFileSync(
       path.join(WORK_DIR, "src", "prompts", "testcase_prompt.txt"),
       "utf-8"
     );
-    if (extraContext) {
-      prompt += `\nAdditional context: ${extraContext}\n`;
+
+    // User-provided data goes in the user prompt to prevent prompt injection
+    let userPrompt = `Endpoint:\n${String(method).toUpperCase()} ${endpoint}\n`;
+    if (payload && Object.keys(payload).length > 0) {
+      userPrompt += `\nSample Payload:\n${JSON.stringify(payload, null, 2)}\n`;
     }
-    logger.info(`[Step3] Prompt constructed. Length: ${prompt.length} chars`);
+    if (extraContext) {
+      userPrompt += `\nAdditional context: ${extraContext}\n`;
+    }
+    logger.info(`[Step3] Prompts constructed. System Length: ${systemPrompt.length}, User Length: ${userPrompt.length}`);
 
     // -----------------------------
     // LLM API call
@@ -143,7 +146,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     let llmJSON: any;
     try {
       llmJSON = await fetchTestCasesFromLLM({
-        prompt,
+        systemPrompt,
+        userPrompt,
         apiUrl: MODEL_API_URL,
         apiKey: MODEL_API_KEY,
         modelName: MODEL_NAME,

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -2,7 +2,8 @@
  * Utility for calling the LLM API and returning parsed test plan JSON.
  */
 export async function fetchTestCasesFromLLM({
-  prompt,
+  systemPrompt,
+  userPrompt,
   apiUrl,
   apiKey,
   modelName,
@@ -10,7 +11,8 @@ export async function fetchTestCasesFromLLM({
   maxTokens,
   logger,
 }: {
-  prompt: string;
+  systemPrompt: string;
+  userPrompt: string;
   apiUrl: string;
   apiKey: string;
   modelName: string;
@@ -33,10 +35,9 @@ export async function fetchTestCasesFromLLM({
         messages: [
           {
             role: "system",
-            content:
-              "You are a helpful assistant that generates software test cases.",
+            content: systemPrompt,
           },
-          { role: "user", content: prompt },
+          { role: "user", content: userPrompt },
         ],
         temperature,
         max_tokens: maxTokens,

--- a/tests/unit/llmService.test.ts
+++ b/tests/unit/llmService.test.ts
@@ -16,7 +16,8 @@ describe("fetchTestCasesFromLLM", () => {
       error: jest.fn(),
     };
     baseParams = {
-      prompt: "Generate tests",
+      systemPrompt: "System instruction",
+      userPrompt: "Generate tests",
       apiUrl: "https://fake-llm.com/api",
       apiKey: "secret",
       modelName: "test-model",


### PR DESCRIPTION
🎯 **What:** Fixed an LLM Prompt Injection vulnerability where user-provided inputs (`endpoint`, `method`, `payload`, `extraContext`) were directly concatenated into a single string along with the developer instructions, making the system susceptible to prompt injection.

⚠️ **Risk:** An attacker could craft a malicious payload or extraContext that overrides the developer's instructions, forcing the LLM to behave in unintended ways or disclose unauthorized information.

🛡️ **Solution:** The prompt has been split into a `systemPrompt` containing all developer instructions/guidelines, and a `userPrompt` containing only the user-provided request data. The `fetchTestCasesFromLLM` service was updated to securely accept and pass these separated prompts to the LLM API using the designated `system` and `user` roles.

---
*PR created automatically by Jules for task [1030043597794394798](https://jules.google.com/task/1030043597794394798) started by @Mallikarjun-Roddannavar*